### PR TITLE
Ignore vendor paths

### DIFF
--- a/cdgo_test.go
+++ b/cdgo_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 )
 
 var _ = Describe("goto", func() {
@@ -21,7 +22,12 @@ var _ = Describe("goto", func() {
 	BeforeSuite(func() {
 		var err error
 		gopath = os.Getenv("GOPATH")
-		cliPath, err = Build("github.com/EngineerBetter/cdgo-cli")
+		currentLocation, err := filepath.Abs(os.Args[0])
+		Ω(err).ShouldNot(HaveOccurred())
+		splitter := strings.Split(currentLocation, "github.com")
+		splitter = strings.Split(splitter[1], "/_test")
+		buildPath := filepath.Join("github.com", splitter[0])
+		cliPath, err = Build(buildPath)
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 

--- a/cdgo_test.go
+++ b/cdgo_test.go
@@ -78,7 +78,6 @@ var _ = Describe("goto", func() {
 
 		Context("when vendor is of no concern", func() {
 			It("finds this directory", func() {
-				gopath := os.Getenv("GOPATH")
 				Ω(gopath).ShouldNot(BeZero())
 
 				command := exec.Command(cliPath, "-needle=cdgo-cli")
@@ -92,7 +91,6 @@ var _ = Describe("goto", func() {
 		})
 
 		It("fails if the directory can't be found", func() {
-			gopath := os.Getenv("GOPATH")
 			Ω(gopath).ShouldNot(BeZero())
 
 			command := exec.Command(cliPath, "-needle=does-not-exist")
@@ -152,7 +150,7 @@ var _ = Describe("goto", func() {
 			session, err = Start(command, GinkgoWriter, GinkgoWriter)
 			Ω(err).ShouldNot(HaveOccurred())
 			Eventually(session).Should(Exit(0))
-			expectedDir := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "EngineerBetter", "cdgo-cli")
+			expectedDir := filepath.Join(gopath, "src", "github.com", "EngineerBetter", "cdgo-cli")
 			Ω(session.Out).Should(Say(expectedDir))
 		})
 	})

--- a/cdgo_test.go
+++ b/cdgo_test.go
@@ -13,10 +13,14 @@ import (
 )
 
 var _ = Describe("goto", func() {
-	var cliPath string
+	var (
+		cliPath string
+		gopath  string
+	)
 
 	BeforeSuite(func() {
 		var err error
+		gopath = os.Getenv("GOPATH")
 		cliPath, err = Build("github.com/EngineerBetter/cdgo-cli")
 		Ω(err).ShouldNot(HaveOccurred())
 	})
@@ -34,17 +38,51 @@ var _ = Describe("goto", func() {
 	})
 
 	Describe("switching to Go dirs", func() {
-		It("finds this directory", func() {
-			gopath := os.Getenv("GOPATH")
-			Ω(gopath).ShouldNot(BeZero())
+		Context("when there is a project in the root of GOPATH that contains the target dir within vendor", func() {
+			BeforeEach(func() {
+				newDirPath := filepath.Join(gopath, "src/cdgo-example/vendor/github.com/EngineerBetter/cdgo-example2")
+				err := os.MkdirAll(newDirPath, 0777)
+				Ω(err).ShouldNot(HaveOccurred())
+				newDirPath = filepath.Join(gopath, "src/github.com/EngineerBetter/cdgo-example2")
+				err = os.MkdirAll(newDirPath, 0777)
+				Ω(err).ShouldNot(HaveOccurred())
+			})
 
-			command := exec.Command(cliPath, "-needle=cdgo-cli")
-			session, err := Start(command, GinkgoWriter, GinkgoWriter)
-			Ω(err).ShouldNot(HaveOccurred())
-			Eventually(session).Should(Exit(0))
+			AfterEach(func() {
+				newDirPath := filepath.Join(gopath, "src/cdgo-example")
+				err := os.RemoveAll(newDirPath)
+				Ω(err).ShouldNot(HaveOccurred())
+				newDirPath = filepath.Join(gopath, "src/github.com/EngineerBetter/cdgo-example2")
+				err = os.RemoveAll(newDirPath)
+				Ω(err).ShouldNot(HaveOccurred())
+			})
 
-			expectedOutput := filepath.Join(gopath, "src/github.com/EngineerBetter/cdgo-cli")
-			Ω(session.Out).Should(Say(expectedOutput))
+			It("finds this directory", func() {
+				Ω(gopath).ShouldNot(BeZero())
+
+				command := exec.Command(cliPath, "-needle=cdgo-example2")
+				session, err := Start(command, GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(Exit(0))
+
+				expectedOutput := filepath.Join(gopath, "src/github.com/EngineerBetter/cdgo-example2")
+				Ω(session.Out).Should(Say(expectedOutput))
+			})
+		})
+
+		Context("when vendor is of no concern", func() {
+			It("finds this directory", func() {
+				gopath := os.Getenv("GOPATH")
+				Ω(gopath).ShouldNot(BeZero())
+
+				command := exec.Command(cliPath, "-needle=cdgo-cli")
+				session, err := Start(command, GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(Exit(0))
+
+				expectedOutput := filepath.Join(gopath, "src/github.com/EngineerBetter/cdgo-cli")
+				Ω(session.Out).Should(Say(expectedOutput))
+			})
 		})
 
 		It("fails if the directory can't be found", func() {

--- a/dir/finder.go
+++ b/dir/finder.go
@@ -41,9 +41,8 @@ func walk(path string, needle string, maxDepth int, currentDepth int) (result st
 		if fileInfo.IsDir() {
 			if fileInfo.Name() == needle {
 				return filename
-			} else {
-				subdirs = append(subdirs, filename)
 			}
+			subdirs = append(subdirs, filename)
 		}
 	}
 

--- a/dir/finder.go
+++ b/dir/finder.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 func Find(needle string, haystack string, maxDepth int) (result string, errOut error) {
@@ -32,6 +33,10 @@ func walk(path string, needle string, maxDepth int, currentDepth int) (result st
 	for _, name := range names {
 		filename := filepath.Join(path, name)
 		fileInfo, _ := os.Lstat(filename)
+
+		if strings.Contains(filename, "/vendor/") {
+			continue
+		}
 
 		if fileInfo.IsDir() {
 			if fileInfo.Name() == needle {


### PR DESCRIPTION
Currently the code base will enter a vendor path to a directory if it walks to it first, it is not useful to cd into vendor so skips any paths containing "/vendor/" when performing find so that they do not ever got walked.
